### PR TITLE
Fix typos in README motivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Common Lisp interpreter written in Python (CLisPy) inspired from [Peter Norvig](http://norvig.com/), [lispy](http://norvig.com/lispy.html) and [lispy.py](http://norvig.com/lispy2.html). This interpreter will be implemented to satisfy　ANSI Common Lisp (Syntax, Macro System, CLOS etc).
 
 ## Motivation
-Comon lisp s-expression have good compatibility with some deep learning frameworks to stack layers. And to build the machine learning model by using scikit-learn, the s-expression also have compatibility for data and model pipline.
+Common Lisp s-expression have good compatibility with some deep learning frameworks to stack layers. And to build the machine learning model by using scikit-learn, the s-expression also have compatibility for data and model pipeline.
 
 ## Required libraries
 - Python 3.x


### PR DESCRIPTION
## Summary
- fix 'Comon lisp' -> 'Common Lisp'
- fix 'pipline' -> 'pipeline'

## Testing
- `./unittest.sh` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6886df8326b0832d8abdf871ce3529d0