### PR TITLE
Fix typos in comments

### DIFF
--- a/clispy/function/special_operator.py
+++ b/clispy/function/special_operator.py
@@ -27,7 +27,7 @@ from clispy.type import BuiltInClass, Symbol, Null, Cons, String
 
 class SpecialOperator(Function):
     """A special forms is a form with special syntax, special evaluation rules
-    or both, possibley manipulating the evaluation environment, control flow,
+    or both, possibly manipulating the evaluation environment, control flow,
     or both.
 
     The set of special operator names is fixed in common lisp; no way is provided
@@ -62,8 +62,8 @@ class SpecialOperator(Function):
 # Defines special operator classes.
 #
 #     Block       Let*                ReturnFrom
-#     Catch       LoadIimeValue       Setq
-#     EvalWhen    Locally             SymbolMcrolet
+#     Catch       LoadTimeValue       Setq
+#     EvalWhen    Locally             SymbolMacrolet
 #     Flet        Macrolet            Tagbody
 #     Function_   MultipleValueCall   The
 #     Go          MultipleValueProg1  Throw
@@ -131,7 +131,7 @@ class EvalWhenSpecialOperator(SpecialOperator):
 
 class FletSpecialOperator(SpecialOperator):
     """flet, labels, and macrolet define local functions and macros, and execute
-    forms using the local definitions. forms are executed in order of occurence.
+    forms using the local definitions. forms are executed in order of occurrence.
 
     The body forms (but not the lambda list) of each function created by flet
     and labels and each macro created by macrolet are enclosed in an implicit
@@ -165,7 +165,7 @@ class FletSpecialOperator(SpecialOperator):
             funcs.append(func.value)
             exp = Cons(Symbol('LAMBDA'), exp)
 
-            # The scope of the name bindings dose not encompasse the function definitions.
+            # The scope of the name bindings does not encompass the function definitions.
             exps.append(Evaluator.eval(exp, var_env, func_env, macro_env))
 
             bindings = bindings.cdr
@@ -249,7 +249,7 @@ class IfSpecialOperator(SpecialOperator):
 
 class LabelsSpecialOperator(SpecialOperator):
     """flet, labels, and macrolet define local functions and macros, and execute
-    forms using the local definitions. forms are executed in order of occurence.
+    forms using the local definitions. forms are executed in order of occurrence.
 
     The body forms (but not the lambda list) of each function created by flet
     and labels and each macro created by macrolet are enclosed in an implicit
@@ -406,7 +406,7 @@ class LocallySpecialOperator(SpecialOperator):
 
 class MacroletSpecialOperator(SpecialOperator):
     """flet, labels, and macrolet define local functions and macros, and execute
-    forms using the local definitions. forms are executed in order of occurence.
+    forms using the local definitions. forms are executed in order of occurrence.
 
     The body forms (but not the lambda list) of each function created by flet
     and labels and each macro created by macrolet are enclosed in an implicit

--- a/clispy/macro/system_macro.py
+++ b/clispy/macro/system_macro.py
@@ -70,7 +70,7 @@ class BlockSystemMacro(SystemMacro):
 
 class FletSystemMacro(SystemMacro):
     """flet, labels, and macrolet define local functions and macros, and execute
-    forms using the local definitions. forms are executed in order of occurence.
+    forms using the local definitions. forms are executed in order of occurrence.
 
     The body forms (but not the lambda list) of each function created by flet
     and labels and each macro created by macrolet are enclosed in an implicit
@@ -133,7 +133,7 @@ class IfSystemMacro(SystemMacro):
 
 class LabelsSystemMacro(SystemMacro):
     """flet, labels, and macrolet define local functions and macros, and execute
-    forms using the local definitions. forms are executed in order of occurence.
+    forms using the local definitions. forms are executed in order of occurrence.
 
     The body forms (but not the lambda list) of each function created by flet
     and labels and each macro created by macrolet are enclosed in an implicit
@@ -151,7 +151,7 @@ class LabelsSystemMacro(SystemMacro):
         return object.__new__(cls)
 
     def __call__(self, forms, var_env, func_env, macro_env):
-        """Behavior of LablesSystemMacro.
+        """Behavior of LabelsSystemMacro.
         """
         from clispy.expander import Expander
 
@@ -199,7 +199,7 @@ class LetAsterSystemMacro(SystemMacro):
     them sequentially.
     """
     def __new__(cls, *args, **kwargs):
-        """Instantiates LetAsterSytemMacro.
+        """Instantiates LetAsterSystemMacro.
         """
         cls.__name__ = 'LET*'
         return object.__new__(cls)
@@ -230,7 +230,7 @@ class QuoteSystemMacro(SystemMacro):
     def __call__(self, forms, var_env, func_env, macro_env):
         """Behavior of QuoteSystemMacro.
         """
-        # Retruns itself.
+        # Returns itself.
         return Cons(Symbol('QUOTE'), forms)
 
 


### PR DESCRIPTION
## Summary
- correct several misspellings in `special_operator` and `system_macro`

## Testing
- `./unittest.sh` *(fails: numpy missing)*

------
https://chatgpt.com/codex/tasks/task_e_6886e2a96640832da404cb0499291ec3