### PR TITLE
Fix return-from for wrapped objects

### DIFF
--- a/clispy/function/special_operator.py
+++ b/clispy/function/special_operator.py
@@ -534,11 +534,11 @@ class ReturnFromSpecialOperator(SpecialOperator):
         # Sets return value.
         retval = Evaluator.eval(body, var_env, func_env, macro_env)
 
-        # name is param of lambda and have throw function as value in call/cc.
-        target = var_env.find(block_name)[block_name]
-        if hasattr(target, 'value'):  # unwrap PyObject
-            target = target.value
-        return target(retval)
+        # During BlockSpecialOperator.__call__, the block is executed with a continuation created by CallCC.
+        # This continuation is passed to the block as a PyObject wrapper in call/cc:
+        #     self.args = Cons(PyObject(Invoke(self)), Null())
+        # See BlockSpecialOperator.__call__ and clispy.callcc.CallCC for more details.
+        return var_env.find(block_name)[block_name].value(retval)  # Unwrap PyObject and execute Invoke object.
 
 
 class SetqSpecialOperator(SpecialOperator):

--- a/clispy/function/special_operator.py
+++ b/clispy/function/special_operator.py
@@ -535,7 +535,10 @@ class ReturnFromSpecialOperator(SpecialOperator):
         retval = Evaluator.eval(body, var_env, func_env, macro_env)
 
         # name is param of lambda and have throw function as value in call/cc.
-        return var_env.find(block_name)[block_name](retval)
+        target = var_env.find(block_name)[block_name]
+        if hasattr(target, 'value'):  # unwrap PyObject
+            target = target.value
+        return target(retval)
 
 
 class SetqSpecialOperator(SpecialOperator):


### PR DESCRIPTION
## Summary
- unwrap block functions before calling them in ReturnFromSpecialOperator

## Testing
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688991bc343c832da07263d9cdebafe1