### PR TITLE
Refactor block and tagbody control flow

### DIFF
--- a/clispy/function/special_operator.py
+++ b/clispy/function/special_operator.py
@@ -679,8 +679,11 @@ class TagbodySpecialOperator(SpecialOperator):
                 while current is not Null():
                     form = current.car
                     current = current.cdr
+
+                    # Skip the tag in the form because it is only expected on the tagbody control flow.
                     if isinstance(form, Symbol) or (hasattr(form, "value") and not isinstance(form, Cons)):
                         continue
+
                     Evaluator.eval(form, local_var_env, func_env, macro_env)
                 return Null()
             except _GoSignal as signal:


### PR DESCRIPTION
## Summary
- replace block/return-from continuation handling with `_BlockReturnSignal`
- reimplement tagbody/go jumps using `_GoSignal` and tag mapping
- update go docs to match exception-based flow

## Testing
- `bash unittest.sh`

------
https://chatgpt.com/codex/tasks/task_e_688f105f8d4c832da2f41f7659ef6d2f