### PR TITLE
Implement runtime documentation database with SQLite

### DIFF
--- a/clispy/__init__.py
+++ b/clispy/__init__.py
@@ -15,6 +15,8 @@
 
 from clispy.interpreter import Interpreter
 from clispy.loader import Loader
+# Ensure runtime built-ins such as DOCUMENTATION are registered
+from clispy import runtime  # noqa: F401
 
 def repl():
     Loader.load("lisp")

--- a/clispy/meta_db.py
+++ b/clispy/meta_db.py
@@ -1,0 +1,163 @@
+import os
+import json
+import sqlite3
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+
+DEFAULT_DB_PATH = os.environ.get(
+    "CLISPY_META_DB", os.path.expanduser("~/.clispy/meta.db")
+)
+
+
+SCHEMA_SQL = """
+-- entities: what the doc attaches to (function, variable, class, etc.)
+CREATE TABLE IF NOT EXISTS entities (
+  id            INTEGER PRIMARY KEY,
+  kind          TEXT NOT NULL,
+  package       TEXT,
+  name          TEXT NOT NULL,
+  extra         TEXT,
+  UNIQUE(kind, package, name)
+);
+
+-- docs: docstring per entity + doc-type
+CREATE TABLE IF NOT EXISTS docs (
+  id            INTEGER PRIMARY KEY,
+  entity_id     INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  doc_type      TEXT NOT NULL,
+  lang          TEXT,
+  content       TEXT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(entity_id, doc_type)
+);
+
+-- history: record of changes and other runtime events
+CREATE TABLE IF NOT EXISTS history (
+  id            INTEGER PRIMARY KEY,
+  entity_id     INTEGER,
+  event_type    TEXT NOT NULL,
+  payload       TEXT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- kv: misc metadata (migration version, etc.)
+CREATE TABLE IF NOT EXISTS kv (
+  k TEXT PRIMARY KEY,
+  v TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_docs_entity ON docs(entity_id);
+CREATE INDEX IF NOT EXISTS idx_history_entity ON history(entity_id);
+"""
+
+
+class MetaDB:
+    _instance = None
+    _lock = threading.Lock()
+
+    def __init__(self, db_path=DEFAULT_DB_PATH):
+        self.db_path = db_path
+        Path(os.path.dirname(db_path)).mkdir(parents=True, exist_ok=True)
+        # relax same-thread check; ensure exclusivity via _lock
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.execute("PRAGMA journal_mode=WAL;")
+        self.conn.execute("PRAGMA foreign_keys=ON;")
+        self._init_schema()
+
+    @classmethod
+    def get(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = MetaDB()
+            return cls._instance
+
+    def _init_schema(self):
+        cur = self.conn.cursor()
+        cur.executescript(SCHEMA_SQL)
+        self.conn.commit()
+
+    @contextmanager
+    def tx(self):
+        with self._lock:
+            try:
+                yield self.conn
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+
+    # --- Entity helpers ---
+    def _upsert_entity(
+        self, kind: str, package: str | None, name: str, extra: dict | None = None
+    ) -> int:
+        extra_s = json.dumps(extra) if extra else None
+        with self.tx() as cx:
+            cx.execute(
+                """INSERT INTO entities(kind, package, name, extra)
+                     VALUES(?,?,?,?)
+                     ON CONFLICT(kind,package,name) DO UPDATE SET extra=COALESCE(excluded.extra, entities.extra)
+                """,
+                (kind, package, name, extra_s),
+            )
+            row = cx.execute(
+                "SELECT id FROM entities WHERE kind=? AND package IS ? AND name=?",
+                (kind, package, name),
+            ).fetchone()
+            return row[0]
+
+    def _get_entity_id(self, kind: str, package: str | None, name: str) -> int | None:
+        row = self.conn.execute(
+            "SELECT id FROM entities WHERE kind=? AND package IS ? AND name=?",
+            (kind, package, name),
+        ).fetchone()
+        return row[0] if row else None
+
+    # --- Docs CRUD ---
+    def set_doc(
+        self, kind, package, name, doc_type, content: str | None, lang: str | None = None
+    ):
+        eid = self._upsert_entity(kind, package, name)
+        with self.tx() as cx:
+            cx.execute(
+                """INSERT INTO docs(entity_id, doc_type, lang, content)
+                       VALUES(?,?,?,?)
+                       ON CONFLICT(entity_id, doc_type)
+                       DO UPDATE SET content=excluded.content, updated_at=datetime('now')""",
+                (eid, doc_type, lang, content),
+            )
+            cx.execute(
+                "INSERT INTO history(entity_id, event_type, payload) VALUES(?,?,?)",
+                (
+                    eid,
+                    "doc:set" if content is not None else "doc:unset",
+                    json.dumps({"doc_type": doc_type, "lang": lang}),
+                ),
+            )
+
+    def get_doc(self, kind, package, name, doc_type) -> str | None:
+        eid = self._get_entity_id(kind, package, name)
+        if eid is None:
+            return None
+        row = self.conn.execute(
+            "SELECT content FROM docs WHERE entity_id=? AND doc_type=?",
+            (eid, doc_type),
+        ).fetchone()
+        return row[0] if row and row[0] is not None else None
+
+    def delete_doc(self, kind, package, name, doc_type):
+        eid = self._get_entity_id(kind, package, name)
+        if eid is None:
+            return
+        with self.tx() as cx:
+            cx.execute(
+                "DELETE FROM docs WHERE entity_id=? AND doc_type=?",
+                (eid, doc_type),
+            )
+            cx.execute(
+                "INSERT INTO history(entity_id, event_type, payload) VALUES(?,?,?)",
+                (eid, "doc:unset", json.dumps({"doc_type": doc_type})),
+            )
+

--- a/clispy/runtime/__init__.py
+++ b/clispy/runtime/__init__.py
@@ -1,0 +1,1 @@
+from clispy.runtime.documentation import *

--- a/clispy/runtime/documentation.py
+++ b/clispy/runtime/documentation.py
@@ -1,0 +1,89 @@
+from clispy.function import SystemFunction
+from clispy.package import PackageManager, assign_helper
+from clispy.type import Null, String, Symbol
+from clispy.meta_db import MetaDB
+
+ALLOWED_DOC_TYPES = {"FUNCTION", "VARIABLE", "TYPE", "STRUCTURE", "CLASS", "SETF"}
+
+def _normalize_symbol(sym):
+    name, package, _ = PackageManager.split_symbol_name(sym.value)
+    if package is None:
+        package = PackageManager.current_package.package_name
+    return package, name
+
+def _normalize_doc_type(sym):
+    if not isinstance(sym, Symbol):
+        return None
+    doc_type = sym.value.upper()
+    if doc_type not in ALLOWED_DOC_TYPES:
+        return None
+    return doc_type
+
+
+class DocumentationSystemFunction(SystemFunction):
+    def __new__(cls, *args, **kwargs):
+        cls.__name__ = "DOCUMENTATION"
+        return object.__new__(cls)
+
+    def __call__(self, forms, var_env, func_env, macro_env):
+        args = self.eval_forms(forms, var_env, func_env, macro_env)
+        thing = args.car
+        doc_type_sym = args.cdr.car
+        if not isinstance(thing, Symbol):
+            return Null()
+        doc_type = _normalize_doc_type(doc_type_sym)
+        if doc_type is None:
+            return Null()
+        package, name = _normalize_symbol(thing)
+        db = MetaDB.get()
+        content = db.get_doc("symbol", package, name, doc_type)
+        if content is None:
+            return Null()
+        return String(content)
+
+
+class SetfDocumentationSystemFunction(SystemFunction):
+    """Update documentation strings in the metadata DB.
+
+    TODO: Convert SELF-DOCUMENTATION to a standard generic function when
+    CLOS becomes available.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        cls.__name__ = "SETF-DOCUMENTATION"
+        return object.__new__(cls)
+
+    def __call__(self, forms, var_env, func_env, macro_env):
+        args = self.eval_forms(forms, var_env, func_env, macro_env)
+        new_doc = args.car
+        thing = args.cdr.car
+        doc_type_sym = args.cdr.cdr.car
+        if not isinstance(thing, Symbol):
+            return new_doc
+        doc_type = _normalize_doc_type(doc_type_sym)
+        if doc_type is None:
+            return new_doc
+        package, name = _normalize_symbol(thing)
+        db = MetaDB.get()
+        if isinstance(new_doc, Null):
+            db.delete_doc("symbol", package, name, doc_type)
+            return Null()
+        else:
+            db.set_doc("symbol", package, name, doc_type, new_doc.value)
+            return new_doc
+
+
+assign_helper(
+    symbol_name="DOCUMENTATION",
+    value=DocumentationSystemFunction(),
+    package_name="COMMON-LISP",
+    env="FUNCTION",
+    status=":EXTERNAL",
+)
+assign_helper(
+    symbol_name="SETF-DOCUMENTATION",
+    value=SetfDocumentationSystemFunction(),
+    package_name="COMMON-LISP",
+    env="FUNCTION",
+    status=":EXTERNAL",
+)

--- a/test/test_documentation.py
+++ b/test/test_documentation.py
@@ -1,0 +1,69 @@
+import os
+import tempfile
+import unittest
+
+# Use a temporary database for tests
+os.environ['CLISPY_META_DB'] = os.path.join(tempfile.gettempdir(), 'clispy_test_meta.db')
+
+from clispy.meta_db import MetaDB
+from clispy.runtime.documentation import (
+    DocumentationSystemFunction,
+    SetfDocumentationSystemFunction,
+)
+from clispy.parser import Parser
+from clispy.package import PackageManager
+from clispy.type import Null, String
+from clispy.expander import Expander
+from clispy.evaluator import Evaluator
+
+
+class DocumentationTestCase(unittest.TestCase):
+    def setUp(self):
+        # Clear database before each test
+        db = MetaDB.get()
+        with db.tx() as cx:
+            cx.execute('DELETE FROM docs')
+            cx.execute('DELETE FROM entities')
+            cx.execute('DELETE FROM history')
+        self.var_env = PackageManager.current_package.env['VARIABLE']
+        self.func_env = PackageManager.current_package.env['FUNCTION']
+        self.macro_env = PackageManager.current_package.env['MACRO']
+        self.doc_fn = DocumentationSystemFunction()
+        self.setf_fn = SetfDocumentationSystemFunction()
+
+    def test_round_trip(self):
+        forms = Parser.parse("('FOO 'FUNCTION)")
+        self.assertEqual(self.doc_fn(forms, self.var_env, self.func_env, self.macro_env), Null())
+        forms = Parser.parse('(SETF (DOCUMENTATION \'FOO \'FUNCTION) "doc")')
+        forms = Expander.expand(forms, self.var_env, self.func_env, self.macro_env)
+        Evaluator.eval(forms, self.var_env, self.func_env, self.macro_env)
+        forms = Parser.parse("('FOO 'FUNCTION)")
+        self.assertEqual(self.doc_fn(forms, self.var_env, self.func_env, self.macro_env), String('doc'))
+        forms = Parser.parse("(NIL 'FOO 'FUNCTION)")
+        self.setf_fn(forms, self.var_env, self.func_env, self.macro_env)
+        forms = Parser.parse("('FOO 'FUNCTION)")
+        self.assertEqual(self.doc_fn(forms, self.var_env, self.func_env, self.macro_env), Null())
+
+    def test_doc_type_independent(self):
+        forms = Parser.parse('("fdoc" \'BAR \'FUNCTION)')
+        self.setf_fn(forms, self.var_env, self.func_env, self.macro_env)
+        forms = Parser.parse('("vdoc" \'BAR \'VARIABLE)')
+        self.setf_fn(forms, self.var_env, self.func_env, self.macro_env)
+        forms = Parser.parse("('BAR 'FUNCTION)")
+        self.assertEqual(self.doc_fn(forms, self.var_env, self.func_env, self.macro_env), String('fdoc'))
+        forms = Parser.parse("('BAR 'VARIABLE)")
+        self.assertEqual(self.doc_fn(forms, self.var_env, self.func_env, self.macro_env), String('vdoc'))
+
+    def test_package_qualified(self):
+        forms = Parser.parse('("pkg" \'CL-USER::BAZ \'FUNCTION)')
+        self.setf_fn(forms, self.var_env, self.func_env, self.macro_env)
+        forms = Parser.parse("('CL-USER::BAZ 'FUNCTION)")
+        self.assertEqual(self.doc_fn(forms, self.var_env, self.func_env, self.macro_env), String('pkg'))
+
+    def test_missing_returns_nil(self):
+        forms = Parser.parse("('NO-SUCH 'FUNCTION)")
+        self.assertEqual(self.doc_fn(forms, self.var_env, self.func_env, self.macro_env), Null())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `MetaDB` SQLite-backed metadata store
- expose `(documentation)` and `(setf documentation)` functions
- support `(setf (documentation ...))` via macro expansion
- annotate `(setf documentation)` helper with TODO for future generic function
- test docstring storage, retrieval, deletion and package handling

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5284079dc832d86b31a6de0d9a893